### PR TITLE
Ruby 3.3.8 Upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,12 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.1.2'
+ruby '3.3.8'
 
 gem 'bootsnap', '>= 1.4.4', require: false
-gem 'pg', '~> 1.1'
+gem 'pg', '~> 1.5'
 gem 'bootstrap', "4.5.3"
-gem 'puma', '~> 5.0'
+gem 'puma', '~> 6.4'
 gem 'rails', '~> 7'
 gem 'redis', '~> 4.0', require: ['redis', 'redis/connection/hiredis']
 gem 'sass-rails', '>= 6'

--- a/Gemfile
+++ b/Gemfile
@@ -68,3 +68,6 @@ gem 'importmap-rails'
 gem 'geocoder'
 gem "redcarpet", "~> 3.6"
 gem 'dotenv-rails', '~> 2.7'
+gem 'mutex_m'
+gem 'bigdecimal'
+gem 'csv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,7 +304,7 @@ GEM
       chunky_png (~> 1.3.7)
     orm_adapter (0.5.0)
     ostruct (0.6.1)
-    pg (1.2.3)
+    pg (1.5.9)
     popper_js (1.16.1)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -312,7 +312,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.6)
-    puma (5.4.0)
+    puma (6.6.0)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.6.1)
@@ -506,10 +506,10 @@ DEPENDENCIES
   memoist (~> 0.16.2)
   meta-tags
   miro (~> 0.4.0)
-  pg (~> 1.1)
+  pg (~> 1.5)
   pry
   pry-rails
-  puma (~> 5.0)
+  puma (~> 6.4)
   rack-mini-profiler (~> 2.0)
   rails (~> 7)
   rails-controller-testing
@@ -526,7 +526,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.1.2p20
+   ruby 3.3.8p144
 
 BUNDLED WITH
    2.6.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
+    bigdecimal (3.2.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     bootsnap (1.7.7)
@@ -145,6 +146,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    csv (3.3.5)
     database_cleaner-active_record (2.0.1)
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
@@ -282,6 +284,7 @@ GEM
       color
       oily_png
     msgpack (1.4.2)
+    mutex_m (0.3.0)
     net-imap (0.3.2)
       date
       net-protocol
@@ -478,6 +481,7 @@ DEPENDENCIES
   attr_json
   bcrypt_pbkdf
   better_errors
+  bigdecimal
   binding_of_caller
   bootsnap (>= 1.4.4)
   bootstrap (= 4.5.3)
@@ -486,6 +490,7 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-rails (~> 1.6)
   capistrano-rbenv (~> 2.2)
+  csv
   database_cleaner-active_record
   devise (~> 4.8)
   dotenv-deployment
@@ -506,6 +511,7 @@ DEPENDENCIES
   memoist (~> 0.16.2)
   meta-tags
   miro (~> 0.4.0)
+  mutex_m
   pg (~> 1.5)
   pry
   pry-rails

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -1,6 +1,6 @@
 module ProjectsHelper
   def cache_key_for_projects(projects = @projects, *extra_keys)
-    max_updated_at = (projects.except(:group, :order).maximum(:updated_at) || Date.today).to_s(:number)
+    max_updated_at = (projects.except(:group, :order).maximum(:updated_at) || Date.today).to_fs(:number)
     key = "projects/#{projects.map(&:id).join('-')}-#{controller_name}-#{max_updated_at}"
     if extra_keys
       key << extra_keys.join("-")

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -10,7 +10,6 @@ set :ssh_options, {forward_agent: true}
 
 # rbenv settings
 set :rbenv_type, :user
-set :rbenv_ruby, "3.1.2"
 set :rbenv_roles, [:app, :db]
 
 # Bundler settings


### PR DESCRIPTION
Some gems won't be bundled with ruby starting with 3.4...

the previous pg wouldn't build, 1.5 does.

upgraded puma just cuz.