### PR TITLE
RSS Project feed

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -31,5 +31,10 @@ class ProjectsController < ApplicationController
 
   def feed
     @projects = Project.recently_added
+
+    @feed_cache_key = if (first = @projects.first)
+      "feed/rss-#{first.id}-#{first.updated_at.to_i}"
+    end
   end
+
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -28,4 +28,8 @@ class ProjectsController < ApplicationController
       return head :ok
     end
   end
+
+  def feed
+    @projects = Project.recently_added
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,8 +2,25 @@
 
 module ApplicationHelper
   def markdown(content)
-    options = [:hard_wrap, :safelink, :autolink, :no_intra_emphasis, :tables, :fenced_code_blocks, link_attributes: {rel: "nofollow noopen", target: :_blank}]
-    Markdown.new(content, *options).to_html.html_safe
+    renderer = Redcarpet::Render::HTML.new(
+      hard_wrap: true,
+      link_attributes: {
+        rel: "nofollow noopener",
+        target: "_blank"
+      }
+    )
+
+    extensions = {
+      autolink: true,
+      no_intra_emphasis: true,
+      fenced_code_blocks: true,
+      tables: true,
+      safelink: true
+    }
+
+    Redcarpet::Markdown.new(
+      renderer, extensions
+    ).render(content.to_s).html_safe
   end
 
   def parent_layout(layout)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -216,6 +216,8 @@ class Project < ApplicationRecord
   scope :hidden, -> { where.not(hidden_at: nil) }
   scope :visible, -> { where(hidden_at: nil).where.not(last_activity_at: nil) }
 
+  scope :recently_added, -> { visible.order(created_at: :desc).limit(20) }
+
   attribute :skip_scan, :boolean, default: false
 
   after_create_commit :scan_project_first!, unless: :skip_scan?
@@ -230,6 +232,12 @@ class Project < ApplicationRecord
 
   def helpers
     Helpers.new(self)
+  end
+
+  def summary_for_feed
+    short_blurb.presence ||
+    description.presence ||
+    "An open-source Ruby on Rails project on GitHub: #{github}"
   end
 
   private

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -210,13 +210,23 @@ class Project < ApplicationRecord
     scope "without_tagged_#{type}".to_sym, -> { without_tagged(type) }
   end
 
-  scope :slim, lambda {
-                 select(:id, :slug, :name, :description, :short_blurb, :color, :updated_at).includes(:adjectives).with_attached_primary_image
-               }
-  scope :hidden, -> { where.not(hidden_at: nil) }
-  scope :visible, -> { where(hidden_at: nil).where.not(last_activity_at: nil) }
+  scope :slim, -> {
+    select(:id, :slug, :name, :description, :short_blurb, :color, :updated_at)
+      .includes(:adjectives)
+      .with_attached_primary_image
+  }
 
-  scope :recently_added, -> { visible.order(created_at: :desc).limit(20) }
+  scope :hidden, -> {
+    where.not(hidden_at: nil)
+  }
+
+  scope :visible, -> {
+    where(hidden_at: nil).where.not(last_activity_at: nil)
+  }
+
+  scope :recently_added, -> {
+    visible.order(created_at: :desc).limit(20)
+  }
 
   attribute :skip_scan, :boolean, default: false
 

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -15,6 +15,7 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
     <link rel="canonical" href="<%= request.url %>">
+    <%= tag(:link, rel: "alternate", type: "application/rss+xml", title: "OSR – Recent Projects", href: feed_url) %>
   </head>
 
   <body>

--- a/app/views/projects/feed.rss.builder
+++ b/app/views/projects/feed.rss.builder
@@ -1,0 +1,26 @@
+Rails.cache.fetch("feed/rss", expires_in: 3.hours) do
+  xml.instruct! :xml, version: "1.0"
+  xml.rss version: "2.0" do
+    xml.channel do
+      xml.title "OSR – Recent Projects"
+      xml.link root_url
+      xml.description "Recently added open-source Ruby on Rails projects"
+      xml.language "en-ca"
+      xml.ttl 1440
+      xml.pubDate @projects.first&.created_at&.rfc2822.to_s
+
+      @projects.each do |project|
+
+        html_description = markdown(project.summary_for_feed)
+
+        xml.item do
+          xml.title project.name
+          xml.description { xml.cdata! html_description }
+          xml.link project_url(project)
+          xml.pubDate project.created_at.rfc2822
+          xml.guid project_url(project)
+        end
+      end
+    end
+  end
+end

--- a/app/views/projects/feed.rss.builder
+++ b/app/views/projects/feed.rss.builder
@@ -1,4 +1,4 @@
-Rails.cache.fetch("feed/rss", expires_in: 3.hours) do
+Rails.cache.fetch(@feed_cache_key, expires_in: 3.hours) do
   xml.instruct! :xml, version: "1.0"
   xml.rss version: "2.0" do
     xml.channel do

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -5,6 +5,21 @@ module Ahoy
     def user
       nil
     end
+
+    def track_visit(data)
+      return if skip_tracking?
+      super
+    end
+
+    def track_event(name, properties, options)
+      return if skip_tracking?
+      super
+    end
+
+    def skip_tracking?
+      request&.path == "/feed.xml"
+    end
+
   end
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ require 'sidekiq-scheduler/web'
 Rails.application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
 
+  get "/feed.xml", to: "projects#feed", defaults: { format: :rss }
+
   ActiveAdmin.routes(self)
   constraints(->(request) { request.env['warden'].authenticate? }) do
     mount Sidekiq::Web => '/admin/sidekiq'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ require 'sidekiq-scheduler/web'
 Rails.application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
 
-  get "/feed.xml", to: "projects#feed", defaults: { format: :rss }
+  get "/feed.xml", to: "projects#feed", defaults: { format: :rss }, as: :feed
 
   ActiveAdmin.routes(self)
   constraints(->(request) { request.env['warden'].authenticate? }) do


### PR DESCRIPTION
1. Added new scope for projects: "recently_added"
2. Feed is accessible via feed_url and points to /feed.xml
3. Updated ahoy initializer to skip feed.xml
4. Rendered feed.xml is cached for 3 hours.
5. A new project or an update to the most recent project expire the cache.